### PR TITLE
Re-enable opencensus python (#103)

### DIFF
--- a/src/emailservice/Dockerfile
+++ b/src/emailservice/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --update --no-cache \
     # App Deps
     cairo-dev \
     cairo \
-    openssl-dev \ 
+    openssl-dev \
     gobject-introspection-dev
 
 # get packages

--- a/src/emailservice/email_client.py
+++ b/src/emailservice/email_client.py
@@ -22,20 +22,20 @@ import demo_pb2_grpc
 from logger import getJSONLogger
 logger = getJSONLogger('emailservice-client')
 
-# from opencensus.trace.tracer import Tracer
-# from opencensus.trace.exporters import stackdriver_exporter
-# from opencensus.trace.ext.grpc import client_interceptor
+from opencensus.trace.tracer import Tracer
+from opencensus.trace.exporters import stackdriver_exporter
+from opencensus.trace.ext.grpc import client_interceptor
 
-# try:
-#     exporter = stackdriver_exporter.StackdriverExporter()
-#     tracer = Tracer(exporter=exporter)
-#     tracer_interceptor = client_interceptor.OpenCensusClientInterceptor(tracer, host_port='0.0.0.0:8080')
-# except:
-#     tracer_interceptor = client_interceptor.OpenCensusClientInterceptor()
+try:
+    exporter = stackdriver_exporter.StackdriverExporter()
+    tracer = Tracer(exporter=exporter)
+    tracer_interceptor = client_interceptor.OpenCensusClientInterceptor(tracer, host_port='0.0.0.0:8080')
+except:
+    tracer_interceptor = client_interceptor.OpenCensusClientInterceptor()
 
 def send_confirmation_email(email, order):
   channel = grpc.insecure_channel('0.0.0.0:8080')
-  # channel = grpc.intercept_channel(channel, tracer_interceptor)
+  channel = grpc.intercept_channel(channel, tracer_interceptor)
   stub = demo_pb2_grpc.EmailServiceStub(channel)
   try:
     response = stub.SendOrderConfirmation(demo_pb2.SendOrderConfirmationRequest(

--- a/src/emailservice/email_server.py
+++ b/src/emailservice/email_server.py
@@ -28,19 +28,18 @@ import demo_pb2_grpc
 from grpc_health.v1 import health_pb2
 from grpc_health.v1 import health_pb2_grpc
 
-# from opencensus.trace.ext.grpc import server_interceptor
-# from opencensus.trace.samplers import always_on
-# from opencensus.trace.exporters import stackdriver_exporter
-# from opencensus.trace.exporters import print_exporter
+from opencensus.trace.exporters import stackdriver_exporter
+from opencensus.trace.ext.grpc import server_interceptor
+from opencensus.trace.samplers import always_on
 
 # import googleclouddebugger
 
-# try:
-#     sampler = always_on.AlwaysOnSampler()
-#     exporter = stackdriver_exporter.StackdriverExporter()
-#     tracer_interceptor = server_interceptor.OpenCensusServerInterceptor(sampler, exporter)
-# except:
-#     tracer_interceptor = server_interceptor.OpenCensusServerInterceptor()
+try:
+    sampler = always_on.AlwaysOnSampler()
+    exporter = stackdriver_exporter.StackdriverExporter()
+    tracer_interceptor = server_interceptor.OpenCensusServerInterceptor(sampler, exporter)
+except:
+    tracer_interceptor = server_interceptor.OpenCensusServerInterceptor()
 
 # try:
 #     googleclouddebugger.enable(
@@ -123,7 +122,8 @@ class HealthCheck():
       status=health_pb2.HealthCheckResponse.SERVING)
 
 def start(dummy_mode):
-  server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))#, interceptors=(tracer_interceptor,))
+  server = grpc.server(futures.ThreadPoolExecutor(max_workers=10),
+                       interceptors=(tracer_interceptor,))
   service = None
   if dummy_mode:
     service = DummyEmailService()

--- a/src/emailservice/requirements.txt
+++ b/src/emailservice/requirements.txt
@@ -8,13 +8,12 @@ cryptography==2.3.1
 entrypoints==0.2.3
 enum34==1.1.6
 futures==3.1.1
-google-api-core==1.4.0
-google-auth==1.5.1
-google-cloud-core==0.28.1
-google-cloud-trace==0.19.0
+google-api-core==1.6.0
+google-auth==1.6.1
+google-cloud-core==0.29.0
 googleapis-common-protos==1.5.3
 grpc-google-iam-v1==0.11.4
-grpcio==1.12.1
+grpcio==1.16.1
 grpcio-health-checking==1.12.1
 grpcio-tools==1.12.1
 idna==2.7
@@ -24,7 +23,7 @@ Jinja2==2.10
 keyring==15.1.0
 keyrings.alt==3.1
 MarkupSafe==1.0
-opencensus==0.1.7
+opencensus[stackdriver]==0.1.10
 protobuf==3.6.1
 pyasn1==0.4.4
 pyasn1-modules==0.2.2

--- a/src/recommendationservice/recommendation_server.py
+++ b/src/recommendationservice/recommendation_server.py
@@ -14,13 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import grpc
-from concurrent import futures
-import time
-import traceback
 import os
 import random
+import time
+import traceback
+from concurrent import futures
+
 import googleclouddebugger
+import grpc
+from opencensus.trace.exporters import print_exporter
+from opencensus.trace.exporters import stackdriver_exporter
+from opencensus.trace.ext.grpc import server_interceptor
+from opencensus.trace.samplers import always_on
 
 import demo_pb2
 import demo_pb2_grpc
@@ -30,11 +35,6 @@ from grpc_health.v1 import health_pb2_grpc
 from logger import getJSONLogger
 logger = getJSONLogger('recommendationservice-server')
 
-# TODO(morganmclean,ahmetb) tracing currently disabled due to memory leak (see TODO below)
-# from opencensus.trace.ext.grpc import server_interceptor
-# from opencensus.trace.samplers import always_on
-# from opencensus.trace.exporters import stackdriver_exporter
-# from opencensus.trace.exporters import print_exporter
 
 class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
     def ListRecommendations(self, request, context):
@@ -63,15 +63,12 @@ class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
 if __name__ == "__main__":
     logger.info("initializing recommendationservice")
 
-    # TODO(morganmclean,ahmetb) enabling the tracing interceptor/sampler below
-    # causes an unbounded memory leak eventually OOMing the container.
-    # ----
-    # try:
-    #     sampler = always_on.AlwaysOnSampler()
-    #     exporter = stackdriver_exporter.StackdriverExporter()
-    #     tracer_interceptor = server_interceptor.OpenCensusServerInterceptor(sampler, exporter)
-    # except:
-    #     tracer_interceptor = server_interceptor.OpenCensusServerInterceptor()
+    try:
+        sampler = always_on.AlwaysOnSampler()
+        exporter = stackdriver_exporter.StackdriverExporter()
+        tracer_interceptor = server_interceptor.OpenCensusServerInterceptor(sampler, exporter)
+    except:
+        tracer_interceptor = server_interceptor.OpenCensusServerInterceptor()
 
     try:
         googleclouddebugger.enable(

--- a/src/recommendationservice/requirements.txt
+++ b/src/recommendationservice/requirements.txt
@@ -3,12 +3,11 @@ certifi==2018.4.16
 chardet==3.0.4
 enum34==1.1.6
 futures==3.2.0
-google-api-core==1.2.1
+google-api-core==1.6.0
 google-api-python-client==1.7.4
-google-auth==1.5.0
+google-auth==1.6.1
 google-auth-httplib2==0.0.3
-google-cloud-core==0.28.1
-google-cloud-trace==0.19.0
+google-cloud-core==0.29.0
 google-python-cloud-debugger==2.8
 googleapis-common-protos==1.5.3
 grpcio==1.13.0
@@ -16,7 +15,7 @@ grpcio-health-checking==1.13.0
 grpcio-tools==1.0.0
 httplib2==0.11.3
 idna==2.7
-opencensus==0.1.5
+opencensus[stackdriver]==0.1.10
 protobuf==3.5.2.post1
 pyasn1==0.4.3
 pyasn1-modules==0.2.2


### PR DESCRIPTION
Enables tracing in the email and recommendation services, which was disabled in 316db88 because of a memory leak in the stackdriver exporter.

We fixed the leak in https://github.com/googleapis/google-cloud-python/pull/6856. The fix is included in the [0.1.10 release of opencensus-python](https://github.com/census-instrumentation/opencensus-python/releases/tag/v0.1.10).

With this diff, traces show up as expected in stackdriver while running the demo on GKE. Using an `opencensus-python` package version before `0.1.10` causes the email and recommendation services to leak memory until they OOM. Memory use is back to normal (i.e. roughly constant) using the new package version.